### PR TITLE
Update config-7-Brcm_WIFI+BT.plist

### DIFF
--- a/10_Kexts_Loading_Sequence_Examples/config-7-Brcm_WIFI+BT.plist
+++ b/10_Kexts_Loading_Sequence_Examples/config-7-Brcm_WIFI+BT.plist
@@ -189,7 +189,7 @@
                     <key>ExecutablePath</key>
                     <string>Contents/MacOS/BrcmFirmwareData</string>
                     <key>MaxKernel</key>
-                    <string>20.9.9</string>
+                    <string></string>
                     <key>MinKernel</key>
                     <string>12.0.0</string>
                     <key>PlistPath</key>


### PR DESCRIPTION
```BrcmFirmwareData.kext``` is used until ventura.